### PR TITLE
Add pagination-friendly batch role loader and move to one-sided role storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,10 @@ $permission->removeRole($role);
 
 If you're using multiple guards the `guard_name` attribute needs to be set as well. Read about it in the [using multiple guards](#using-multiple-guards) section of the readme.
 
-The `HasRoles` trait adds Moloquent relationships to your models, which can be accessed directly or used as a base query:
+The `HasRoles` trait exposes role accessors and query helpers that read role IDs
+stored on your model (e.g. `role_ids` on the user). This avoids writing inverse
+IDs (like `user_ids`/`person_ids`) into the roles collection, which keeps writes
+one-sided while still allowing fast lookups by role:
 
 ```php
 // get a list of all permissions directly assigned to the user
@@ -315,6 +318,14 @@ $roles = $user->roles->pluck('name'); // Returns a collection
 
 // get all role names
 $roles = $user->getRoleNames() // Returns a collection;
+```
+
+If you need the equivalent of eager-loading roles for a paginated list (without
+defining a `roles()` relationship), use the batch helper:
+
+```php
+$people = Person::query()->paginate();
+Person::loadRolesFor($people);
 ```
 
 The `HasRoles` trait also adds a `role` scope to your models to scope the query to certain roles or permissions:

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -14,6 +14,7 @@ use Maklad\Permission\Traits\RefreshesPermissionCache;
 use MongoDB\Laravel\Eloquent\Model;
 use ReflectionException;
 use function app;
+use function collect;
 
 /**
  * Class Permission
@@ -113,6 +114,85 @@ class Permission extends Model implements PermissionInterface
     public function getRolesAttribute(): mixed
     {
         return $this->rolesQuery()->get();
+    }
+
+    /**
+     * Assign the given role(s) to the permission.
+     *
+     * @param array|string|Role ...$roles
+     *
+     * @return array
+     * @throws ReflectionException
+     */
+    public function assignRole(...$roles): array
+    {
+        $roles = collect($roles)
+            ->flatten()
+            ->map(function ($role) {
+                return $this->getStoredRole($role);
+            })
+            ->each(function ($role) {
+                $this->ensureModelSharesGuard($role);
+            });
+
+        $roles->each(function ($role) {
+            $role->givePermissionTo($this);
+        });
+
+        return $roles->all();
+    }
+
+    /**
+     * Revoke the given role(s) from the permission.
+     *
+     * @param array|string|Role ...$roles
+     *
+     * @return array
+     * @throws ReflectionException
+     */
+    public function removeRole(...$roles): array
+    {
+        $roles = collect($roles)
+            ->flatten()
+            ->map(function ($role) {
+                return $this->getStoredRole($role);
+            });
+
+        $roles->each(function ($role) {
+            $role->revokePermissionTo($this);
+        });
+
+        return $roles->all();
+    }
+
+    /**
+     * Remove all current roles and set the given ones.
+     *
+     * @param array ...$roles
+     *
+     * @return array
+     * @throws ReflectionException
+     */
+    public function syncRoles(...$roles): array
+    {
+        $roles = collect($roles)
+            ->flatten()
+            ->map(function ($role) {
+                return $this->getStoredRole($role);
+            })
+            ->each(function ($role) {
+                $this->ensureModelSharesGuard($role);
+            });
+
+        $this->roles->each(function ($role) {
+            $role->revokePermissionTo($this);
+        });
+
+        $roles->each(function ($role) {
+            $role->givePermissionTo($this);
+        });
+
+        return $roles->all();
     }
 
     /**

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -3,12 +3,13 @@
 namespace Maklad\Permission\Traits;
 
 use Illuminate\Support\Collection;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Maklad\Permission\Contracts\RoleInterface as Role;
 use Maklad\Permission\Helpers;
 use Maklad\Permission\PermissionRegistrar;
 use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Eloquent\Builder;
-use MongoDB\Laravel\Relations\BelongsToMany;
 use ReflectionException;
 use function collect;
 
@@ -29,7 +30,8 @@ trait HasRoles
                 return;
             }
 
-            $model->roles()->sync([]);
+            $model->role_ids = [];
+            $model->save();
         });
     }
 
@@ -42,11 +44,28 @@ trait HasRoles
     }
 
     /**
-     * A model may have multiple roles.
+     * Query roles by the stored role IDs.
+     *
+     * We intentionally avoid defining a roles() relationship because Eloquent
+     * treats roles() as a relationship method and will throw if it does not
+     * return a Relation instance. The MongoDB driver will also write inverse IDs
+     * (e.g. person_ids) into the roles collection.
+     * Returning a relationship instance also makes Eloquent treat roles() as a
+     * relationship, which isn't desired for one-sided role storage. Instead we
+     * expose roles via an accessor and query helper that read role_ids directly.
      */
-    public function roles(): BelongsToMany|\Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function rolesQuery(): Builder
     {
-        return $this->belongsToMany(config('permission.models.role'));
+        $roleClass = $this->getRoleClass();
+        return $roleClass->query()->whereIn('_id', $this->role_ids ?? []);
+    }
+
+    /**
+     * Gets the roles attribute.
+     */
+    public function getRolesAttribute(): Collection
+    {
+        return $this->rolesQuery()->get();
     }
 
     /**
@@ -81,14 +100,19 @@ trait HasRoles
             })
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
-            })
+            });
+
+        $this->role_ids = collect($this->role_ids ?? [])
+            ->merge($roles->pluck('_id'))
+            ->unique()
+            ->values()
             ->all();
 
-        $this->roles()->saveMany($roles);
+        $this->save();
 
         $this->forgetCachedPermissions();
 
-        return $roles;
+        return $roles->all();
     }
 
     /**
@@ -100,18 +124,24 @@ trait HasRoles
      */
     public function removeRole(...$roles)
     {
-        collect($roles)
+        $roles = collect($roles)
             ->flatten()
             ->map(function ($role) {
-                $role = $this->getStoredRole($role);
-                $this->roles()->detach($role);
-
-                return $role;
+                return $this->getStoredRole($role);
             });
+
+        $this->role_ids = collect($this->role_ids ?? [])
+            ->reject(function ($roleId) use ($roles) {
+                return $roles->pluck('_id')->contains($roleId);
+            })
+            ->values()
+            ->all();
+
+        $this->save();
 
         $this->forgetCachedPermissions();
 
-        return $roles;
+        return $roles->all();
     }
 
     /**
@@ -124,7 +154,8 @@ trait HasRoles
      */
     public function syncRoles(...$roles): Role|array|string
     {
-        $this->roles()->sync([]);
+        $this->role_ids = [];
+        $this->save();
 
         return $this->assignRole($roles);
     }
@@ -209,7 +240,62 @@ trait HasRoles
      */
     public function getRoleNames(): Collection
     {
-        return $this->roles()->pluck('name');
+        return $this->rolesQuery()->pluck('name');
+    }
+
+    /**
+     * Batch-load roles for a collection or paginator of models.
+     *
+     * This is the eager-loading replacement for the omitted roles() relationship.
+     * It keeps one-sided role storage (role_ids on the model) while still allowing
+     * paginated results to attach roles without triggering RelationNotFound errors.
+     *
+     * @param Collection|Paginator|LengthAwarePaginator $models
+     *
+     * @return Collection
+     */
+    public static function loadRolesFor($models): Collection
+    {
+        if ($models instanceof Paginator || $models instanceof LengthAwarePaginator) {
+            $models = $models->getCollection();
+        }
+
+        if (! $models instanceof Collection) {
+            $models = collect($models);
+        }
+
+        if ($models->isEmpty()) {
+            return $models;
+        }
+
+        $roleClass = app(PermissionRegistrar::class)->getRoleClass();
+        $roleIds = $models
+            ->pluck('role_ids')
+            ->flatten()
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($roleIds->isEmpty()) {
+            $models->each(function (Model $model) {
+                $model->setAttribute('roles', collect());
+            });
+
+            return $models;
+        }
+
+        $roles = $roleClass->query()->whereIn('_id', $roleIds)->get()->keyBy('_id');
+
+        $models->each(function (Model $model) use ($roles) {
+            $roleIds = collect($model->role_ids ?? []);
+            $modelRoles = $roleIds->map(function ($roleId) use ($roles) {
+                return $roles->get($roleId);
+            })->filter()->values();
+
+            $model->setAttribute('roles', $modelRoles);
+        });
+
+        return $models;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent Eloquent from treating `roles()` as a relationship (which triggers Relation errors) and avoid the MongoDB driver writing inverse IDs into the `roles` collection. 
- Keep role membership writes one-sided on the model (`role_ids`) while preserving read/query and eager-like capabilities. 
- Provide a pagination-friendly way to attach role objects to paginated results without defining a `roles()` relation. 
- Add reciprocal role helpers on `Permission` to manage role↔permission associations consistently.

### Description
- Replace the `roles()` relationship with a query helper `rolesQuery()` and an accessor `getRolesAttribute()` that read `role_ids` directly and import pagination contracts with `use Illuminate\Contracts\Pagination\Paginator;` and `LengthAwarePaginator` in `HasRoles`. 
- Convert role writes to one-sided storage by clearing `role_ids` in `bootHasRoles`, and update `assignRole`, `removeRole`, and `syncRoles` to update `role_ids` and call `save()` instead of syncing a BelongsToMany relation. 
- Add `public static function loadRolesFor($models): Collection` in `HasRoles` to batch-load and attach `roles` to a `Collection` or paginated results without a relationship, including handling empty role lists and keying loaded roles by `_id`. 
- Extend `Permission` with `assignRole`, `removeRole`, and `syncRoles` helpers and import `collect` where needed, and update `README.md` with example usage of `Person::loadRolesFor($paginator)`.

### Testing
- Ran `composer test`, which exited with an error because `phpunit` is not available in the environment, so automated tests did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69665e3f8320832fa53371e84c38367f)